### PR TITLE
Update README.md installation steps to allow a clean install first shot

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 1. Clone this repo into custom_nodes directory of ComfyUI location
 
-2. Run pip install -r requirements.txt
+2. cd ComfyUI/custom_nodes/ComfyUI-Moore-AnimateAnyone & python tools/download_weights.py
 
-3. cd ComfyUI/custom_nodes/ComfyUI-Moore-AnimateAnyone & python tools/download_weights.py
+3. Run pip install -r requirements.txt
 
 ## Examples
 


### PR DESCRIPTION
From what i've experienced, to properly install you need to download the pretrained weights first, as a first step I'd suggest to say so in the readme.

We could also create an install.sh or somth like that to automatically download them.

thanks for your work <3