### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-moore-animateanyone"
+description = "Nodes: Run python tools/download_weights.py first to download weights automatically"
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["accelerate>=0.21.0", "av>=11.0.0", "clip @ https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip#sha256=b5842c25da441d6c581b53a5c60e0c2127ebafe0f746f8e15561a006c6c3be6a", "decord>=0.6.0", "diffusers==0.24.0", "einops>=0.4.1", "imageio>=2.33.0", "imageio-ffmpeg>=0.4.9", "numpy>=1.23.5", "omegaconf>=2.2.3", "onnxruntime>=1.16.3", "onnxruntime-gpu>=1.16.3", "open-clip-torch>=2.20.0", "opencv-contrib-python>=4.8.1.78", "opencv-python>=4.8.1.78", "Pillow>=9.5.0", "scikit-image>=0.21.0", "scikit-learn>=1.3.2", "scipy>=1.11.4", "torchdiffeq>=0.2.3", "torchmetrics>=1.2.1", "torchsde>=0.2.5", "tqdm>=4.66.1", "transformers>=4.30.2"]
+
+[project.urls]
+Repository = "https://github.com/chaojie/ComfyUI-Moore-AnimateAnyone"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-Moore-AnimateAnyone"
+Icon = ""


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [ ] Go to the [registry](https://comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [ ] Write a short the description.
- [ ] Merge the separate Github Actions PR and run the workflow.

If you want to publish the node manually, [install the cli](https://comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`
Please message me on [Discord](https://discord.com/invite/comfyorg) if you have any questions!