### PR TITLE
Update to work with newer Diffusers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ accelerate>=0.21.0
 av>=11.0.0
 clip @ https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip#sha256=b5842c25da441d6c581b53a5c60e0c2127ebafe0f746f8e15561a006c6c3be6a
 decord>=0.6.0
-diffusers==0.24.0
+diffusers>=0.25.2
 einops>=0.4.1
 imageio>=2.33.0
 imageio-ffmpeg>=0.4.9

--- a/src/models/transformer_2d.py
+++ b/src/models/transformer_2d.py
@@ -4,7 +4,11 @@ from typing import Any, Dict, Optional
 
 import torch
 from diffusers.configuration_utils import ConfigMixin, register_to_config
-from diffusers.models.embeddings import CaptionProjection
+import diffusers
+if diffusers.__version__ >'0.25':
+    from diffusers.models.embeddings import PixArtAlphaTextProjection as CaptionProjection
+else:
+    from diffusers.models.embeddings import CaptionProjection
 from diffusers.models.lora import LoRACompatibleConv, LoRACompatibleLinear
 from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import AdaLayerNormSingle

--- a/src/models/unet_2d_blocks.py
+++ b/src/models/unet_2d_blocks.py
@@ -6,7 +6,11 @@ import torch
 import torch.nn.functional as F
 from diffusers.models.activations import get_activation
 from diffusers.models.attention_processor import Attention
-from diffusers.models.dual_transformer_2d import DualTransformer2DModel
+import diffusers
+if diffusers.__version__ >'0.25':
+    from diffusers.models.transformers.dual_transformer_2d import DualTransformer2DModel
+else:
+    from diffusers.models.dual_transformer_2d import DualTransformer2DModel
 from diffusers.models.resnet import Downsample2D, ResnetBlock2D, Upsample2D
 from diffusers.utils import is_torch_version, logging
 from diffusers.utils.torch_utils import apply_freeu

--- a/src/models/unet_2d_condition.py
+++ b/src/models/unet_2d_condition.py
@@ -20,13 +20,18 @@ from diffusers.models.embeddings import (
     ImageHintTimeEmbedding,
     ImageProjection,
     ImageTimeEmbedding,
-    PositionNet,
+    # PositionNet,
     TextImageProjection,
     TextImageTimeEmbedding,
     TextTimeEmbedding,
     TimestepEmbedding,
     Timesteps,
 )
+import diffusers
+if diffusers.__version__ >'0.25':
+    from diffusers.models.embeddings import GLIGENTextBoundingboxProjection as PositionNet
+else:
+    from diffusers.models.embeddings import PositionNet
 from diffusers.models.modeling_utils import ModelMixin
 from diffusers.utils import (
     USE_PEFT_BACKEND,


### PR DESCRIPTION
There are 3 modules that changed names after Diffusers 0.25.0, this new code in the import section checks if Diffusers is >0.25 and loads the modules by their new names instead. Tested and working on my copy of Comfy using Diffusers 0.32.2